### PR TITLE
Updated CSS for predictive form for smaller screens

### DIFF
--- a/app/static/map.css
+++ b/app/static/map.css
@@ -341,3 +341,27 @@ input[type=time], input[type=button], #dateDropdown {
   width: 240px;
   outline: none;
 }
+
+/*CSS for predictive form when screen width is less than 380*/
+@media only screen and (max-width: 380px) {
+
+  /* CSS for the form */
+  #predictionForm {
+    width: 205px;
+  }
+
+  /* CSS for the form fields */
+  input[type=time], #dateDropdown {
+    padding: 2px 6px;
+    width: 67px;
+    font-size: 0.6em;
+  }
+  
+  /* CSS for the button */
+  input[type=button] {
+    padding: 4px;
+    width: 52px;
+    font-weight: bold;
+    font-size: 0.7em;
+  }
+}


### PR DESCRIPTION
For screens smaller than 380px i.e. smaller mobile phone screens